### PR TITLE
Add ability to disable drag

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ const App = () => {
 | ------------------------ | :----------------------------------------------: | :--------------------------------------------: | ------: |
 | **onSortEnd\***          | Called when the user finishes a sorting gesture. | `(oldIndex: number, newIndex: number) => void` |       - |
 | **draggedItemClassName** |     Class applied to the item being dragged      |                    `string`                    |       - |
+| **allowDrag**            |     Determines whether items can be dragged      |                    `boolean`                   |   `true`|
+
 
 ### SortableItem
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,8 @@ import { Point } from './types'
 
 type Props = HTMLAttributes<HTMLDivElement> & {
   children: React.ReactNode
+  /** Determines whether drag functionality is enabled, defaults to true */
+  allowDrag?: boolean | undefined
   /** Called when the user finishes a sorting gesture. */
   onSortEnd: (oldIndex: number, newIndex: number) => void
   /** Class applied to the item being dragged */
@@ -22,7 +24,7 @@ type Context = {
 
 const SortableListContext = React.createContext<Context | undefined>(undefined)
 
-const SortableList = ({ children, onSortEnd, draggedItemClassName, ...rest }: Props) => {
+const SortableList = ({ children, allowDrag = true, onSortEnd, draggedItemClassName, ...rest }: Props) => {
   // this array contains the elements than can be sorted (wrapped inside SortableItem)
   const itemsRef = React.useRef<HTMLElement[]>([])
   // this array contains the coordinates of each sortable element (only computed on dragStart and used in dragMove for perf reason)
@@ -232,7 +234,7 @@ const SortableList = ({ children, onSortEnd, draggedItemClassName, ...rest }: Pr
   const context = React.useMemo(() => ({ registerItem, removeItem }), [registerItem, removeItem])
 
   return (
-    <div {...listeners} {...rest} ref={containerRef}>
+    <div {...(allowDrag ? listeners : {})} {...rest} ref={containerRef}>
       <SortableListContext.Provider value={context}>{children}</SortableListContext.Provider>
     </div>
   )

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,7 @@ import { Point } from './types'
 type Props = HTMLAttributes<HTMLDivElement> & {
   children: React.ReactNode
   /** Determines whether drag functionality is enabled, defaults to true */
-  allowDrag?: boolean | undefined
+  allowDrag?: boolean
   /** Called when the user finishes a sorting gesture. */
   onSortEnd: (oldIndex: number, newIndex: number) => void
   /** Class applied to the item being dragged */


### PR DESCRIPTION
Greetings,

This PR adds the ability to disable the drag function on a list. As a user, I want to be able to edit a sortable list(a collection of inputs for example), without it dragging when clicking and typing. This can be achieved by passing the allowDrag prop, and temporarily disable drag listeners.

If you are uninterested in this idea, I can whip something up to only allow dragging from a specific component. That may be more ideal.

Please let me know, thanks.

<img width="576" alt="Screen Shot 2021-06-25 at 1 21 33 PM" src="https://user-images.githubusercontent.com/57921318/123462390-44ce4680-d5b8-11eb-98d4-f999e4dce1cf.png">

