### PR TITLE
Fix unnecessary list rendering

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -260,9 +260,7 @@ const SortableList = <TTag extends keyof JSX.IntrinsicElements = typeof DEFAULT_
       ...rest, 
       ref: containerRef
     },
-    [
-      <SortableListContext.Provider value={context}>{children}</SortableListContext.Provider>
-    ]
+    <SortableListContext.Provider value={context}>{children}</SortableListContext.Provider>
   ) 
 }
 


### PR DESCRIPTION
In my [last](https://github.com/ricardo-ch/react-easy-sort/pull/18) PR I've made a simple mistake while rendering children of `SortableList`. I should have rendered single child instead of a list. This is an obvious post factum fix.

Current codebase results in warning `Each child in a list should have a unique "key" prop.` in the console. 